### PR TITLE
Fix working treesitter >0.23

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,7 @@
         ["OS!='win'", {
           "cflags_c": [
             "-std=c11",
+            "-fPIC"
           ],
         }, { # OS == "win"
           "cflags_c": [

--- a/bindings/python/tree_sitter_powershell/__init__.pyi
+++ b/bindings/python/tree_sitter_powershell/__init__.pyi
@@ -1,1 +1,6 @@
-def language() -> int: ...
+from typing import Final
+
+HIGHLIGHTS_QUERY: Final[str]
+TAGS_QUERY: Final[str]
+
+def language() -> object: ...

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-powershell",
-  "version": "0.24.4",
+  "version": "1.2.0",
   "description": "",
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
     "generate": "tree-sitter generate",
-    "build-node": "tree-sitter generate && node-gyp build",
+    "build-node": "tree-sitter generate --no-bindings",
     "test": "tree-sitter test",
     "parse": "tree-sitter parse",
     "parse-debug": "tree-sitter parse -d",
@@ -31,8 +31,21 @@
   "devDependencies": {
     "node-gyp": "^9.4.0",
     "prebuildify": "^6.0.0",
-    "tree-sitter-cli": "0.24.4"
+    "tree-sitter-cli": "^0.22.6"
   },
+  "tree-sitter": [
+    {
+      "scope": "source.ps1",
+      "file-types": [
+        "ps1",
+        "psm1"
+      ],
+      "injection-regex": "^(ps1|psm1)$",
+      "highlights": [
+        "queries/highlights.scm"
+      ]
+    }
+  ],
   "files": [
     "grammar.js",
     "binding.gyp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,28 +2,26 @@
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[project]
+[tool.poetry]
 name = "tree-sitter-powershell"
-description = "Powershell grammar for tree-sitter"
 version = "0.0.1"
-keywords = ["incremental", "parsing", "tree-sitter", "powershell"]
-classifiers = [
-  "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
-  "Topic :: Software Development :: Compilers",
-  "Topic :: Text Processing :: Linguistic",
-  "Typing :: Typed"
-]
-requires-python = ">=3.8"
-license.text = "MIT"
+description = "PowerShell grammar for tree-sitter"
+authors = ["Your Name <your.email@example.com>"]
+license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/tree-sitter/tree-sitter-powershell"
+keywords = ["incremental", "parsing", "tree-sitter", "powershell"]
+include = [
+    "src/*",
+    "bindings/python/tree_sitter_powershell/binding.c"
+]
 
-[project.urls]
-Homepage = "https://github.com/tree-sitter/tree-sitter-powershell"
 
-[project.optional-dependencies]
-core = ["tree-sitter==0.24"]
+[tool.poetry.dependencies]
+python = ">=3.11"
+tree-sitter = { version = "^0.23", optional = true }
+
 
 [tool.cibuildwheel]
-build = "cp38-*"
+build = "cp39-*"
 build-frontend = "build"

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ class Build(build):
 
 class BdistWheel(bdist_wheel):
     def get_tag(self):
-        python, abi, platform = super().get_tag()
-        if python.startswith("cp"):
-            python, abi = "cp38", "abi3"
-        return python, abi, platform
+        powershell, abi, platform = super().get_tag()
+        if powershell.startswith("cp"):
+            powershell, abi = "cp39", "abi3"
+        return powershell, abi, platform
 
 
 setup(
@@ -36,17 +36,19 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_powershell/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c",
             ],
             extra_compile_args=[
                 "-std=c11",
+                "-fvisibility=hidden",
             ] if system() != "Windows" else [
                 "/std:c11",
                 "/utf-8",
             ],
             define_macros=[
-                ("Py_LIMITED_API", "0x03080000"),
-                ("PY_SSIZE_T_CLEAN", None)
+                ("Py_LIMITED_API", "0x03090000"),
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
             ],
             include_dirs=["src"],
             py_limited_api=True,


### PR DESCRIPTION
marco made it work, after error 

`Process SpawnProcess-1:
Traceback (most recent call last):
  File "/Users/dnoordman/.pyenv/versions/3.12.8/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/dnoordman/.pyenv/versions/3.12.8/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/uvicorn/_subprocess.py", line 80, in subprocess_started
    target(sockets=sockets)
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dnoordman/.pyenv/versions/3.12.8/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/dnoordman/.pyenv/versions/3.12.8/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 69, in serve
    await self._serve(sockets)
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 76, in _serve
    config.load()
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/uvicorn/config.py", line 434, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dnoordman/.pyenv/versions/3.12.8/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/dnoordman/ai-code-insight/api/cis/main.py", line 16, in <module>
    from cis.src.analyzers.base_analyzer import Analyzer
  File "/Users/dnoordman/ai-code-insight/api/cis/src/analyzers/base_analyzer.py", line 9, in <module>
    from cis.src.parsers.base_file_parser import BaseFileParser
  File "/Users/dnoordman/ai-code-insight/api/cis/src/parsers/base_file_parser.py", line 11, in <module>
    from cis.src.parsers.utils import Utils
  File "/Users/dnoordman/ai-code-insight/api/cis/src/parsers/utils.py", line 7, in <module>
    import tree_sitter_powershell
  File "/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/tree_sitter_powershell/__init__.py", line 3, in <module>
    from ._binding import language
ImportError: dlopen(/Users/dnoordman/ai-code-insight/api/.venv/lib/python3.12/site-packages/tree_sitter_powershell/_binding.abi3.so, 0x0002): symbol not found in flat namespace '_tree_sitter_powershell_external_scanner_create'
`